### PR TITLE
fix: precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
+		"prepare": "husky install",
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",
@@ -36,6 +37,6 @@
 		"pretty-quick": "^3.1.3"
 	},
 	"lint-staged": {
-		"*.{js,css,md,mdx,html,json}": "prettier --write"
+		"*.{js,mjs,css,md,mdx,html,json,astro}": "prettier --write"
 	}
 }


### PR DESCRIPTION
Changes:
- Add `prepare` script for ` husky` initialization
- Format `mjs` and `astro` extensions on precommit hook